### PR TITLE
Update main.c

### DIFF
--- a/main.c
+++ b/main.c
@@ -7,8 +7,8 @@ int main(void)
     while(1)
     {
     	DrvGPIO_ClrBit(E_GPC,15);
-    	DrvSYS_Delay(1000000);
+    	DrvSYS_Delay(500000);
     	DrvGPIO_SetBit(E_GPC,15);
-    	DrvSYS_Delay(1000000);
+    	DrvSYS_Delay(500000);
     }
 }


### PR DESCRIPTION
DrvSYSDelay() should delay a LED. Then this program will blink LED.

So based on code DrvSYSDelay(1000000) it mean 1us (1microsecond) and DrvSYSDelay(500000) delay 500ms.

but when i flash it on Nuvoton nuc140ve3cn. DrvSYSDelay(1000000) is blinking faster then DrvSYSDelay(500000).

What's wrong?
